### PR TITLE
Fix/report aggregation

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1,5 +1,5 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.example</groupId>
   <artifactId>SerenityExample</artifactId>
@@ -20,6 +20,8 @@
     <maven.sufire-plugin.version>3.0.0-M5</maven.sufire-plugin.version>
     <spring-boot-maven-plugin.version>2.3.12.RELEASE</spring-boot-maven-plugin.version>
     <selenium.version>4.8.0</selenium.version>
+    <node.version>v18.16.0</node.version>
+    <frontend-maven-plugin.version>1.12.1</frontend-maven-plugin.version>
   </properties>
 
   <parent>
@@ -114,23 +116,72 @@
         </executions>
       </plugin>
       <plugin>
-        <groupId>net.serenity-bdd.maven.plugins</groupId>
-        <artifactId>serenity-maven-plugin</artifactId>
-        <version>${serenity.version}</version>
-        <dependencies>
-          <dependency>
-            <groupId>net.serenity-bdd</groupId>
-            <artifactId>serenity-core</artifactId>
-            <version>${serenity.version}</version>
-          </dependency>
-        </dependencies>
+        <!-- https://github.com/eirslett/frontend-maven-plugin -->
+        <groupId>com.github.eirslett</groupId>
+        <artifactId>frontend-maven-plugin</artifactId>
+        <version>${frontend-maven-plugin.version}</version>
+
+        <configuration>
+          <nodeVersion>${node.version}</nodeVersion>
+
+          <!-- optional: where to download node and npm from. Defaults to https://nodejs.org/dist/ -->
+          <!-- <downloadRoot>http://artifactory.example.org/nodejs/</downloadRoot> -->
+        </configuration>
+
         <executions>
           <execution>
-            <id>serenity-reports</id>
-            <phase>post-integration-test</phase>
+            <id>Install Node.js and npm</id>
             <goals>
-              <goal>aggregate</goal>
+              <goal>install-node-and-npm</goal>
             </goals>
+            <phase>initialize</phase>
+            <configuration>
+              <installDirectory>target</installDirectory>
+            </configuration>
+          </execution>
+
+          <execution>
+            <id>npm install</id>
+            <goals>
+              <goal>npm</goal>
+            </goals>
+            <phase>initialize</phase>
+            <configuration>
+              <installDirectory>target</installDirectory>
+              <workingDirectory>src/test/playwright/</workingDirectory>
+              <arguments>install</arguments>
+            </configuration>
+          </execution>
+
+          <execution>
+            <id>Serenity/JS tests</id>
+            <goals>
+              <goal>npm</goal>
+            </goals>
+
+            <!-- optional: the default phase is "test" -->
+            <phase>integration-test</phase>
+
+            <configuration>
+              <installDirectory>target</installDirectory>
+              <workingDirectory>src/test/playwright/</workingDirectory>
+              <arguments>run test:execute</arguments>
+            </configuration>
+          </execution>
+
+          <execution>
+            <id>Serenity BDD report</id>
+            <goals>
+              <goal>npm</goal>
+            </goals>
+
+            <phase>post-integration-test</phase>
+
+            <configuration>
+              <installDirectory>target</installDirectory>
+              <workingDirectory>./src/test/playwright/</workingDirectory>
+              <arguments>run test:report</arguments>
+            </configuration>
           </execution>
         </executions>
       </plugin>

--- a/src/test/playwright/package-lock.json
+++ b/src/test/playwright/package-lock.json
@@ -19,10 +19,10 @@
         "cucumber-html-reporter": "5.5.0"
       },
       "devDependencies": {
-        "@serenity-js/console-reporter": "^3.0.0-rc.42",
-        "@serenity-js/core": "^3.0.0-rc.42",
-        "@serenity-js/cucumber": "^3.0.0-rc.42",
-        "@serenity-js/serenity-bdd": "^3.0.0-rc.42",
+        "@serenity-js/console-reporter": "^3.1.5",
+        "@serenity-js/core": "^3.1.5",
+        "@serenity-js/cucumber": "^3.1.5",
+        "@serenity-js/serenity-bdd": "^3.1.5",
         "@types/expect": "24.3.0",
         "@types/fs-extra": "11.0.1",
         "@types/lodash": "4.14.191",
@@ -487,6 +487,18 @@
         "@jridgewell/sourcemap-codec": "^1.4.10"
       }
     },
+    "node_modules/@noble/hashes": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.3.0.tgz",
+      "integrity": "sha512-ilHEACi9DwqJB0pw7kv+Apvh50jiiSyR/cQ3y4W7lOR5mhvn/50FLUfsnfJz0BDZtl/RR16kXvptiv6q1msYZg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://paulmillr.com/funding/"
+        }
+      ]
+    },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
@@ -522,6 +534,15 @@
         "node": ">= 8"
       }
     },
+    "node_modules/@paralleldrive/cuid2": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@paralleldrive/cuid2/-/cuid2-2.2.0.tgz",
+      "integrity": "sha512-CVQDpPIUHrUGGLdrMGz1NmqZvqmsB2j2rCIQEu1EvxWjlFh4fhvEGmgR409cY20/67/WlJsggenq0no3p3kYsw==",
+      "dev": true,
+      "dependencies": {
+        "@noble/hashes": "^1.1.5"
+      }
+    },
     "node_modules/@playwright/test": {
       "version": "1.30.0",
       "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.30.0.tgz",
@@ -538,12 +559,12 @@
       }
     },
     "node_modules/@serenity-js/assertions": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/@serenity-js/assertions/-/assertions-3.0.1.tgz",
-      "integrity": "sha512-Quh8O+sj/Y7NIttHOsaj9E+3KSIh9l8QKo6rLxlNbrXxyay6F1zHZIMGD2mEpouYfHfG2iAEazEWVhgMFKLaQQ==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/@serenity-js/assertions/-/assertions-3.1.5.tgz",
+      "integrity": "sha512-7xtt0wiFRg3R4JgPobX/aM/Uun2yWVnIr7gwux18N/dOacZrvQQGI/dbYAWGWi410yE6iGbGVTXeyjcdZZspnQ==",
       "dev": true,
       "dependencies": {
-        "@serenity-js/core": "3.0.1",
+        "@serenity-js/core": "3.1.5",
         "tiny-types": "^1.19.1"
       },
       "engines": {
@@ -555,12 +576,12 @@
       }
     },
     "node_modules/@serenity-js/console-reporter": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/@serenity-js/console-reporter/-/console-reporter-3.0.1.tgz",
-      "integrity": "sha512-ZcDz284caL7YfGf9WEt3iNf7WNv85MCoVTqOylRSlL8usdR5HhiU1Xhek89SBdxizgxng6zRlSDIFcwkWajkcg==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/@serenity-js/console-reporter/-/console-reporter-3.1.5.tgz",
+      "integrity": "sha512-J58bCQ441oC5y3kJWZ7p/lI4IUBxqzDypN+04HGNCKN3HlN2qw4kgxxqjIDdmv4L4yD4Api3kotJBSThp1g8Ow==",
       "dev": true,
       "dependencies": {
-        "@serenity-js/core": "3.0.1",
+        "@serenity-js/core": "3.1.5",
         "chalk": "^4.1.2",
         "tiny-types": "^1.19.1"
       },
@@ -573,20 +594,20 @@
       }
     },
     "node_modules/@serenity-js/core": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/@serenity-js/core/-/core-3.0.1.tgz",
-      "integrity": "sha512-c43iWLImO1fnD4gQ1BlhySmzg3cAqUi5tSB36dzebbluLZTzV4CF30ir4tyi/XZ8MYQAlr/R5CFCn6e6q/0iwQ==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/@serenity-js/core/-/core-3.1.5.tgz",
+      "integrity": "sha512-7D5B3qbTF/ZTHmwHSrMp0IV/mH3GnBiQR97aHCg3V0Oa+1M/EzTHUBzFanRsbCk9rD7ZQ6aZD15LOvqrSmGUWA==",
       "dev": true,
       "dependencies": {
+        "@paralleldrive/cuid2": "^2.2.0",
         "chalk": "^4.1.2",
-        "cuid": "^2.1.8",
         "diff": "^5.1.0",
         "error-stack-parser": "2.1.4",
         "fast-glob": "^3.2.12",
         "filenamify": "^4.3.0",
         "graceful-fs": "^4.2.11",
         "moment": "^2.29.4",
-        "semver": "^7.3.8",
+        "semver": "^7.4.0",
         "tiny-types": "^1.19.1",
         "upath": "^2.0.1",
         "validate-npm-package-name": "^5.0.0"
@@ -599,14 +620,29 @@
         "url": "https://github.com/sponsors/serenity-js"
       }
     },
-    "node_modules/@serenity-js/cucumber": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/@serenity-js/cucumber/-/cucumber-3.0.1.tgz",
-      "integrity": "sha512-1cD5vvj7tknRxt5HgDB+bvgU2PZkRcjjqu5FdWAt2sRqls4jwkmmFfU2MWU4TaBqj6mQloZ0BiAt8U9o+UxcOw==",
+    "node_modules/@serenity-js/core/node_modules/semver": {
+      "version": "7.5.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.0.tgz",
+      "integrity": "sha512-+XC0AD/R7Q2mPSRuy2Id0+CGTZ98+8f+KvwirxOKIEyid+XSx6HbC63p+O4IndTHuX5Z+JxQ0TghCkO5Cg/2HA==",
       "dev": true,
       "dependencies": {
-        "@cucumber/messages": "^20.0.0",
-        "@serenity-js/core": "3.0.1",
+        "lru-cache": "^6.0.0"
+      },
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@serenity-js/cucumber": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/@serenity-js/cucumber/-/cucumber-3.1.5.tgz",
+      "integrity": "sha512-rp7G4MCd16Gv/m1SAgjrWMpLzTwVpJAePFYuwzX7K7OxpC2sLABdEfG6hUZAksXnStPiy4S49UkcXZY20bxUBw==",
+      "dev": true,
+      "dependencies": {
+        "@cucumber/messages": "21.0.1",
+        "@serenity-js/core": "3.1.5",
         "cli-table3": "^0.6.3",
         "gherkin": "5.1.0",
         "tiny-types": "^1.19.1"
@@ -619,7 +655,7 @@
         "url": "https://github.com/sponsors/serenity-js"
       },
       "peerDependencies": {
-        "@cucumber/cucumber": "^7.3.2 || ^8.5.0",
+        "@cucumber/cucumber": "^7.3.2 || ^8.5.0 || ^9.1.0",
         "cucumber": "^1.3.3 || ^2.3.1 || ^3.2.1 || ^4.2.1 || ^5.0.0 || ^6.0.0"
       },
       "peerDependenciesMeta": {
@@ -631,26 +667,14 @@
         }
       }
     },
-    "node_modules/@serenity-js/cucumber/node_modules/@cucumber/messages": {
-      "version": "20.0.0",
-      "resolved": "https://registry.npmjs.org/@cucumber/messages/-/messages-20.0.0.tgz",
-      "integrity": "sha512-JFrFwuhxsbig0afaViNhuzoQyC+GQzlI7m+rX+lSiDGV13K3sJzMmHjkbCiNOgoRlKAMwIGR9TRMH0xj9/My0w==",
-      "dev": true,
-      "dependencies": {
-        "@types/uuid": "8.3.4",
-        "class-transformer": "0.5.1",
-        "reflect-metadata": "0.1.13",
-        "uuid": "9.0.0"
-      }
-    },
     "node_modules/@serenity-js/rest": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/@serenity-js/rest/-/rest-3.0.1.tgz",
-      "integrity": "sha512-MHfZrUxqBagmbHF4MFYUINPQaiBHarU1PEzKilp0+43m/QEkkpkfEuEs3NPhTsCc2kFVqrMavq7XBQLOz693Cg==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/@serenity-js/rest/-/rest-3.1.5.tgz",
+      "integrity": "sha512-yfN/x49XySqKlpQjSX1cl09p7wmnOV+2EPXKm7AdNYFNjKyaT0+SaE9a//itlm36gGgP6D4hw1pUjr32a43opw==",
       "dev": true,
       "dependencies": {
-        "@serenity-js/core": "3.0.1",
-        "axios": "^1.3.4"
+        "@serenity-js/core": "3.1.5",
+        "axios": "^1.3.5"
       },
       "engines": {
         "node": "^14 || ^16 || ^18",
@@ -661,16 +685,16 @@
       }
     },
     "node_modules/@serenity-js/serenity-bdd": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/@serenity-js/serenity-bdd/-/serenity-bdd-3.0.1.tgz",
-      "integrity": "sha512-FWKuTVEUkN/8VhnhXY2vhS1gkm7vC58vvdlv5JZvvFTOm/3Jat4XFT1U5WBtNck27HxNrF/BM75SpRAQihDgRw==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/@serenity-js/serenity-bdd/-/serenity-bdd-3.1.5.tgz",
+      "integrity": "sha512-AoLqPcHLluKWKwT2KDGqHmi089/q/OZprn7iKhIxMaf7jMqRSAVxkFhK/DhOzv6EMz75Nuu6nT5cYBBd7hj1uA==",
       "dev": true,
       "dependencies": {
-        "@serenity-js/assertions": "3.0.1",
-        "@serenity-js/core": "3.0.1",
-        "@serenity-js/rest": "3.0.1",
+        "@serenity-js/assertions": "3.1.5",
+        "@serenity-js/core": "3.1.5",
+        "@serenity-js/rest": "3.1.5",
         "ansi-regex": "^5.0.1",
-        "axios": "^1.3.4",
+        "axios": "^1.3.5",
         "chalk": "^4.1.2",
         "find-java-home": "^2.0.0",
         "https-proxy-agent": "^5.0.1",
@@ -1356,9 +1380,9 @@
       }
     },
     "node_modules/axios": {
-      "version": "1.3.4",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.3.4.tgz",
-      "integrity": "sha512-toYm+Bsyl6VC5wSkfkbbNB6ROv7KY93PEBBL6xyDczaIHasAiv4wPqQ/c4RjoQzipxRD2W5g21cOqQulZ7rHwQ==",
+      "version": "1.3.5",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.3.5.tgz",
+      "integrity": "sha512-glL/PvG/E+xCWwV8S6nCHcrfg1exGx7vxyUIivIA1iL7BIh6bePylCfVHwp6k13ao7SATxB6imau2kqY+I67kw==",
       "dev": true,
       "dependencies": {
         "follow-redirects": "^1.15.0",
@@ -2074,13 +2098,6 @@
       "bin": {
         "uuid": "bin/uuid"
       }
-    },
-    "node_modules/cuid": {
-      "version": "2.1.8",
-      "resolved": "https://registry.npmjs.org/cuid/-/cuid-2.1.8.tgz",
-      "integrity": "sha512-xiEMER6E7TlTPnDxrM4eRiC6TRgjNX9xzEZ5U/Se2YJKr7Mq4pJn/2XEHjl3STcSh96GmkHPcBXLES8M29wyyg==",
-      "deprecated": "Cuid and other k-sortable and non-cryptographic ids (Ulid, ObjectId, KSUID, all UUIDs) are all insecure. Use @paralleldrive/cuid2 instead.",
-      "dev": true
     },
     "node_modules/dargs": {
       "version": "7.0.0",

--- a/src/test/playwright/package.json
+++ b/src/test/playwright/package.json
@@ -6,7 +6,7 @@
     "clean": "rimraf target",
     "test": "failsafe clean test:execute test:report",
     "test:execute": "cucumber-js",
-    "test:report": "serenity-bdd run --features ../resources/features/ --source ../../../target/site/serenity/ --destination ../../../target/site/serenity/ --artifact='net.serenity-bdd:serenity-cli:jar:3.6.12' --log debug"
+    "test:report": "serenity-bdd run --features ../resources/features/ --source ../../../target/site/serenity/ --destination ../../../target/site/serenity/ --artifact='net.serenity-bdd:serenity-cli:jar:3.6.12' --shortFilenames false --log debug"
   },
   "dependencies": {
     "@cucumber/cucumber": "8.11.0",
@@ -19,10 +19,10 @@
     "cucumber-html-reporter": "5.5.0"
   },
   "devDependencies": {
-    "@serenity-js/console-reporter": "^3.0.0-rc.42",
-    "@serenity-js/core": "^3.0.0-rc.42",
-    "@serenity-js/cucumber": "^3.0.0-rc.42",
-    "@serenity-js/serenity-bdd": "^3.0.0-rc.42",
+    "@serenity-js/console-reporter": "^3.1.5",
+    "@serenity-js/core": "^3.1.5",
+    "@serenity-js/cucumber": "^3.1.5",
+    "@serenity-js/serenity-bdd": "^3.1.5",
     "@types/expect": "24.3.0",
     "@types/fs-extra": "11.0.1",
     "@types/lodash": "4.14.191",

--- a/src/test/playwright/package.json
+++ b/src/test/playwright/package.json
@@ -6,7 +6,7 @@
     "clean": "rimraf target",
     "test": "failsafe clean test:execute test:report",
     "test:execute": "cucumber-js",
-    "test:report": "serenity-bdd run --features ../resources/features/ --source ../../../target/site/serenity/ --artifact='net.serenity-bdd:serenity-cli:jar:3.6.12'"
+    "test:report": "serenity-bdd run --features ../resources/features/ --source ../../../target/site/serenity/ --destination ../../../target/site/serenity/ --artifact='net.serenity-bdd:serenity-cli:jar:3.6.12' --log debug"
   },
   "dependencies": {
     "@cucumber/cucumber": "8.11.0",


### PR DESCRIPTION
Hey Eoin! I've:
- added [frontend-maven-plugin](https://github.com/eirslett/frontend-maven-plugin) to make invoking Serenity/JS tests and running report aggregation easier
- improved support for nested requirement hierarchies - the issue was a difference in how Serenity/JS and recent Serenity BDD handle directory names with uppercase characters). See release notes for [Serenity/JS 3.1.5](https://serenity-js.org/changelog/3.1.5)
- upgraded Serenity/JS to 3.1.5 in your project

Running `mvn clean verify` now:
- runs Serenity BDD tests
- runs Serenity/JS tests
- produces an aggregated report